### PR TITLE
小小的更新

### DIFF
--- a/.mochaopts
+++ b/.mochaopts
@@ -6,3 +6,4 @@
 --require ignore-styles
 --compilers js:babel-core/register
 --compilers jsx:babel-core/register
+app/dist/**/__test__/**/*.test.*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true,
+  "jsxBracketSameLine": true
+}

--- a/app/dist/containers/09_Hoc/index.jsx
+++ b/app/dist/containers/09_Hoc/index.jsx
@@ -253,7 +253,11 @@ console.log(storeData); // { 'keyB.foo': 100, keyC: true, 'keyD.baz.0.qux': 300 
     </h4>
     <div style={{ padding: '5px 10px 20px' }}>
       <p>
-        用法與 store 相同，但是會多實作 shouldComponentUpdate 的 props 比對。{' '}
+        用法與{' '}
+        <a href="#store" style={{ color: '#000' }}>
+          # Store
+        </a>{' '}
+        相同，但是會多實作 shouldComponentUpdate 的 props 比對。{' '}
       </p>
     </div>
     <h4 id="style">

--- a/app/dist/containers/09_Hoc/index.jsx
+++ b/app/dist/containers/09_Hoc/index.jsx
@@ -246,6 +246,16 @@ console.log(storeData); // { 'keyB.foo': 100, keyC: true, 'keyD.baz.0.qux': 300 
         </div>
       </div>
     </div>
+    <h4 id="store">
+      <a href="#store" style={{ color: '#000' }}>
+        # PureStore(...storeKeys)(component)
+      </a>
+    </h4>
+    <div style={{ padding: '5px 10px 20px' }}>
+      <p>
+        用法與 store 相同，但是會多實作 shouldComponentUpdate 的 props 比對。{' '}
+      </p>
+    </div>
     <h4 id="style">
       <a href="#style" style={{ color: '#000' }}>
         # Style(...css)(component)

--- a/app/dist/core/container/connect.js
+++ b/app/dist/core/container/connect.js
@@ -67,7 +67,7 @@ export const _connect2 = (storeKey?: Array<string>) =>
       ...ownProps
     }),
     {
-      pure: true,
+      pure: false,
       withRef: false
     }
   );
@@ -89,7 +89,7 @@ export const _connect3 = (storeKey?: Array<string>) =>
       ...ownProps
     }),
     {
-      pure: true,
+      pure: false,
       withRef: false
     }
   );

--- a/app/dist/core/container/hoc/store.jsx
+++ b/app/dist/core/container/hoc/store.jsx
@@ -18,13 +18,28 @@ type ConnectProps = {
   CONNECT_RES: any
 };
 
-export default (...storeKey: Array<string>) => (WrapperComponent: any) => {
+export const PureStore = (...storeKey: Array<string>) => (
+  WrapperComponent: any
+) => {
   class StoreClass extends Component<void, ConnectProps, void> {
     props: ConnectProps;
 
     shouldComponentUpdate(nextProps: ConnectProps) {
       return !objectEqual(nextProps, this.props);
     }
+
+    render() {
+      const { CONNECT_RES, ...others } = this.props;
+      return <WrapperComponent storeData={CONNECT_RES} {...others} />;
+    }
+  }
+
+  return _connect1(storeKey)(StoreClass);
+};
+
+export default (...storeKey: Array<string>) => (WrapperComponent: any) => {
+  class StoreClass extends Component<void, ConnectProps, void> {
+    props: ConnectProps;
 
     render() {
       const { CONNECT_RES, ...others } = this.props;

--- a/app/dist/core/container/index.js
+++ b/app/dist/core/container/index.js
@@ -2,7 +2,8 @@
 import Dispatch from './hoc/dispatch';
 import I18n from './hoc/i18n';
 import Store from './hoc/store';
+import { PureStore } from './hoc/store';
 import Style from './hoc/style';
 import { compose } from 'redux';
 
-export { compose, Dispatch, I18n, Store, Style };
+export { compose, Dispatch, I18n, PureStore, Store, Style };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mega",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -8,14 +8,14 @@
     "production": "npm run build; NODE_ENV=production webpack -p --config ./webpack.prod.config.js",
     "build": "node app/build.js || exit",
     "start": "npm run build; NODE_ENV=development webpack-dev-server --devtool eval --progress --colors --config ./webpack.dev.config.js",
-    "test": "NODE_ENV=test nyc mocha --opts ./.mochaopts \"app/dist/**/__test__/**/*.test.*\" || exit 0",
+    "test": "NODE_ENV=test nyc mocha --opts ./.mochaopts",
     "coverage-report": "NODE_ENV=test nyc report --reporter=lcov --reporter=text --reporter=text-summary",
     "flow-install": "flow-typed install --overwrite",
     "flow-test": "flow || notify -t 'Flow Type' -m 'something mistake'",
     "flow-test:watch": "npm run flow-test; fswatch -e ./**/* -o 1 | xargs -n1 -I{} sh -c 'tput setaf 6; date \"+\n[%m/%d %H:%M:%S]\";tput sgr0; npm run flow-test'",
-    "mocha-test:watch": "NODE_ENV=test mocha --watch --opts ./.mochaopts \"app/dist/**/__test__/**/*.test.*\"",
+    "mocha-test:watch": "NODE_ENV=test mocha --watch --opts ./.mochaopts",
     "precommit": "lint-staged",
-    "prettier": "prettier --single-quote --jsx-bracket-same-line --write \"app/dist/**/*.{js,jsx,css,scss,sass}\""
+    "prettier": "prettier --write \"app/dist/**/*.{js,jsx,css,scss,sass}\""
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
- 新增 prettier 設定檔：統一格式
- 將單元測試路徑寫入 .mochaopts 中
- core/container 新增 PureStore。用法同 Store 但是會多做 `shouldComponentUpdate` 的比較